### PR TITLE
adding downshift of fold change

### DIFF
--- a/MSAbundanceSim.gemspec
+++ b/MSAbundanceSim.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Simulate protein abundances.}
   spec.description   = %q{Simulate protein abundances given FASTA files.}
   spec.homepage      = "https://github.com/optimusmoose/MSAbundanceSim"
+  spec.licenses      = ['GPL-3.0']
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
+  t.warning = false
 end
 
 task :default => :test

--- a/test/ms_abundance_sim_test.rb
+++ b/test/ms_abundance_sim_test.rb
@@ -27,4 +27,12 @@ describe MSAbundanceSim do
     reply.must_equal 0.08406721711401088
   end
 
+  it "downshifts values" do
+    result = MSAbundanceSim.downshift(value=4, min_threshold=0, probability_threshold=0.75, amount=1.5, random=0.76)
+    result.must_equal 4
+
+    result = MSAbundanceSim.downshift(value=4, min_threshold=0, probability_threshold=0.75, amount=1.5, random=0.74)
+    result.must_equal 2.5
+  end
+
 end


### PR DESCRIPTION
For three-quarters of all fold changes that are above 0, subtract 1 from the fold change.

- This also adds commandline parameters to control the setting.
- The function itself is tested and the default cmdline behavior was tested by hand to ensure it was performing the downshift to fold changes as described above.
- Also removed the srand line.